### PR TITLE
EIP-5725 Review: Improve vesting terminology

### DIFF
--- a/EIP-draft.md
+++ b/EIP-draft.md
@@ -61,7 +61,7 @@ import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
 /**
  * @title Non-Fungible Vesting Token Standard
- * @notice A non-fungible token standard used to vest tokens (ERC-20 or otherwise) over a vesting release curve
+ * @notice A non-fungible token standard used to vest tokens (EIP-20 or otherwise) over a vesting release curve
  *  scheduled using timestamps.
  * @dev Because this standard relies on timestamps for the vesting schedule, it's important to keep track of the
  *  tokens claimed per Vesting NFT so that a user cannot withdraw more tokens than alloted for a specific Vesting NFT.

--- a/contracts/ERC5725.sol
+++ b/contracts/ERC5725.sol
@@ -84,6 +84,19 @@ abstract contract ERC5725 is IERC5725, ERC721 {
     /**
      * @dev See {IERC5725}.
      */
+    function claimedPayout(uint256 tokenId)
+        public
+        view
+        override(IERC5725)
+        validToken(tokenId)
+        returns (uint256 payout)
+    {
+        return _payoutClaimed[tokenId];
+    }
+
+    /**
+     * @dev See {IERC5725}.
+     */
     function vestingPeriod(uint256 tokenId)
         public
         view
@@ -103,7 +116,7 @@ abstract contract ERC5725 is IERC5725, ERC721 {
 
     /**
      * @dev See {IERC165-supportsInterface}.
-     * IERC5725 interfaceId = 0xf8600f8b
+     * IERC5725 interfaceId = 0x7c89676d
      */
     function supportsInterface(bytes4 interfaceId)
         public

--- a/contracts/IERC5725.sol
+++ b/contracts/IERC5725.sol
@@ -31,7 +31,7 @@ interface IERC5725 is IERC721 {
     /**
      * @notice Number of tokens for the NFT which have been claimed at the current timestamp
      * @param tokenId The NFT token id
-     * @return payout The total amount of payout tokens claimed for this NFT 
+     * @return payout The total amount of payout tokens claimed for this NFT
      */
     function claimedPayout(uint256 tokenId) external view returns (uint256 payout);
 

--- a/contracts/IERC5725.sol
+++ b/contracts/IERC5725.sol
@@ -4,7 +4,7 @@ import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
 /**
  * @title Non-Fungible Vesting Token Standard
- * @notice A non-fungible token standard used to vest tokens (ERC-20 or otherwise) over a vesting release curve
+ * @notice A non-fungible token standard used to vest tokens (EIP-20 or otherwise) over a vesting release curve
  *  scheduled using timestamps.
  * @dev Because this standard relies on timestamps for the vesting schedule, it's important to keep track of the
  *  tokens claimed per Vesting NFT so that a user cannot withdraw more tokens than alloted for a specific Vesting NFT.
@@ -22,17 +22,18 @@ interface IERC5725 is IERC721 {
      * @notice Claim the pending payout for the NFT
      * @dev MUST grant the claimablePayout value at the time of claim being called
      * MUST revert if not called by the token owner or approved users
+     * MUST emit PayoutClaimed
      * SHOULD revert if there is nothing to claim
      * @param tokenId The NFT token id
      */
     function claim(uint256 tokenId) external;
 
     /**
-     * @notice Number of tokens for the NFT which have been claimed
+     * @notice Number of tokens for the NFT which have been claimed at the current timestamp
      * @param tokenId The NFT token id
      * @return payout The total amount of payout tokens claimed for this NFT 
      */
-    function payoutClaimed(uint256 tokenId) external view returns (uint256 payout);
+    function claimedPayout(uint256 tokenId) external view returns (uint256 payout);
 
     /**
      * @notice Number of tokens for the NFT which can be claimed at the current timestamp

--- a/contracts/IERC5725.sol
+++ b/contracts/IERC5725.sol
@@ -28,6 +28,21 @@ interface IERC5725 is IERC721 {
     function claim(uint256 tokenId) external;
 
     /**
+     * @notice Number of tokens for the NFT which have been claimed
+     * @param tokenId The NFT token id
+     * @return payout The total amount of payout tokens claimed for this NFT 
+     */
+    function payoutClaimed(uint256 tokenId) external view returns (uint256 payout);
+
+    /**
+     * @notice Number of tokens for the NFT which can be claimed at the current timestamp
+     * @dev It is RECOMMENDED that this is calculated as the `vestedPayout()` subtracted from `payoutClaimed()`.
+     * @param tokenId The NFT token id
+     * @return payout The amount of unlocked payout tokens for the NFT which have not yet been claimed
+     */
+    function claimablePayout(uint256 tokenId) external view returns (uint256 payout);
+
+    /**
      * @notice Total amount of tokens which have been vested at the current timestamp.
      *   This number also includes vested tokens which have been claimed.
      * @dev It is RECOMMENDED that this function calls `vestedPayoutAtTime` with
@@ -49,22 +64,12 @@ interface IERC5725 is IERC721 {
     function vestedPayoutAtTime(uint256 tokenId, uint256 timestamp) external view returns (uint256 payout);
 
     /**
-     * @notice Number of tokens for an NFT which are currently vesting (locked).
+     * @notice Number of tokens for an NFT which are currently vesting.
      * @dev The sum of vestedPayout and vestingPayout SHOULD always be the total payout.
      * @param tokenId The NFT token id
-     * @return payout The number of tokens for the NFT which have not been claimed yet,
-     *   regardless of whether they are ready to claim
+     * @return payout The number of tokens for the NFT which are vesting until a future date.
      */
     function vestingPayout(uint256 tokenId) external view returns (uint256 payout);
-
-    /**
-     * @notice Number of tokens for the NFT which can be claimed at the current timestamp
-     * @dev It is RECOMMENDED that this is calculated as the `vestedPayout()` value with the total
-     * amount of tokens claimed subtracted.
-     * @param tokenId The NFT token id
-     * @return payout The number of vested tokens for the NFT which have not been claimed yet
-     */
-    function claimablePayout(uint256 tokenId) external view returns (uint256 payout);
 
     /**
      * @notice The start and end timestamps for the vesting of the provided NFT

--- a/docs/ERC5725.md
+++ b/docs/ERC5725.md
@@ -62,6 +62,14 @@ function claimablePayout(uint256 tokenId) public view returns (uint256 payout)
 
 _See {IERC5725}._
 
+### claimedPayout
+
+```solidity
+function claimedPayout(uint256 tokenId) public view returns (uint256 payout)
+```
+
+_See {IERC5725}._
+
 ### vestingPeriod
 
 ```solidity
@@ -85,7 +93,7 @@ function supportsInterface(bytes4 interfaceId) public view virtual returns (bool
 ```
 
 _See {IERC165-supportsInterface}.
-IERC5725 interfaceId = 0xf8600f8b_
+IERC5725 interfaceId = 0x7c89676d_
 
 ### _payoutToken
 

--- a/docs/IERC5725.md
+++ b/docs/IERC5725.md
@@ -2,7 +2,7 @@
 
 ## IERC5725
 
-A non-fungible token standard used to vest tokens (ERC-20 or otherwise) over a vesting release curve
+A non-fungible token standard used to vest tokens (EIP-20 or otherwise) over a vesting release curve
  scheduled using timestamps.
 
 _Because this standard relies on timestamps for the vesting schedule, it's important to keep track of the
@@ -29,11 +29,46 @@ Claim the pending payout for the NFT
 
 _MUST grant the claimablePayout value at the time of claim being called
 MUST revert if not called by the token owner or approved users
+MUST emit PayoutClaimed
 SHOULD revert if there is nothing to claim_
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | tokenId | uint256 | The NFT token id |
+
+### claimedPayout
+
+```solidity
+function claimedPayout(uint256 tokenId) external view returns (uint256 payout)
+```
+
+Number of tokens for the NFT which have been claimed at the current timestamp
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenId | uint256 | The NFT token id |
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| payout | uint256 | The total amount of payout tokens claimed for this NFT |
+
+### claimablePayout
+
+```solidity
+function claimablePayout(uint256 tokenId) external view returns (uint256 payout)
+```
+
+Number of tokens for the NFT which can be claimed at the current timestamp
+
+_It is RECOMMENDED that this is calculated as the `vestedPayout()` subtracted from `payoutClaimed()`._
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tokenId | uint256 | The NFT token id |
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| payout | uint256 | The amount of unlocked payout tokens for the NFT which have not yet been claimed |
 
 ### vestedPayout
 
@@ -82,7 +117,7 @@ Zero MUST be returned if the timestamp is before the token was minted._
 function vestingPayout(uint256 tokenId) external view returns (uint256 payout)
 ```
 
-Number of tokens for an NFT which are currently vesting (locked).
+Number of tokens for an NFT which are currently vesting.
 
 _The sum of vestedPayout and vestingPayout SHOULD always be the total payout._
 
@@ -92,26 +127,7 @@ _The sum of vestedPayout and vestingPayout SHOULD always be the total payout._
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| payout | uint256 | The number of tokens for the NFT which have not been claimed yet,   regardless of whether they are ready to claim |
-
-### claimablePayout
-
-```solidity
-function claimablePayout(uint256 tokenId) external view returns (uint256 payout)
-```
-
-Number of tokens for the NFT which can be claimed at the current timestamp
-
-_It is RECOMMENDED that this is calculated as the `vestedPayout()` value with the total
-amount of tokens claimed subtracted._
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| tokenId | uint256 | The NFT token id |
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| payout | uint256 | The number of vested tokens for the NFT which have not been claimed yet |
+| payout | uint256 | The number of tokens for the NFT which are vesting until a future date. |
 
 ### vestingPeriod
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "lint:ts:fix": "prettier --write ./{scripts,tasks,src,hardhat,test}/**/*.ts",
     "lint:ci": "yarn lint",
     "list:networks": "hardhat verify --list-networks",
-    "clean": "node ./hardhat/utils/clean.js"
+    "clean": "node ./hardhat/utils/clean.js",
+    "precommit": "yarn lint:ci && yarn test:ci && yarn gen:docs"
   },
   "repository": {
     "type": "git",

--- a/test/VestingNFT.test.ts
+++ b/test/VestingNFT.test.ts
@@ -48,7 +48,7 @@ describe('VestingNFT', function () {
      * const interfaceId = await vestingNFT.IID_ITEST();
      */
     // Vesting NFT Interface ID
-    expect(await vestingNFT.supportsInterface('0xf8600f8b')).to.equal(true)
+    expect(await vestingNFT.supportsInterface('0x7c89676d')).to.equal(true)
   })
 
   it('Returns a valid vested payout', async function () {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,16 +15,16 @@
     "index.ts",
     "artifacts/**/*.json",
     "src",
-    "typechain-types"
+    "typechain-types",
+    "test",
+    "hardhat.config.ts",
   ],
   // The intent here is to only include src/ and Smart Contract artifacts and types.
   "exclude": [
     "dist",
     "hardhat",
     "tasks",
-    "test",
     "scripts",
-    "hardhat.config.ts",
     "prettier.config.js",
     "solhint.config.js"
   ]


### PR DESCRIPTION
- Update terms to provide for the standard to support vested tokens which are locked
- add `claimedPayout(uint256 tokenId)` so that the amount of "vested but locked" tokens can be calculated.
- add more details on possible extensions

### Other review
- I looked over the [Solidity style guide](https://docs.soliditylang.org/en/latest/style-guide.html) again with the intention that the EIP follows it.  

- [x] If approved, then the reference implementation needs to be updated before with `claimedPayout`
