### PR TITLE
[feat] implement and prove allowance mechanism for ERC5725

### DIFF
--- a/EIP-draft.md
+++ b/EIP-draft.md
@@ -2,7 +2,7 @@
 eip: 5725
 title: Transferable Vesting NFT
 description: An interface for transferable vesting NFTs which release underlying tokens over time.
-author: Apeguru (@Apegurus), Marco De Vries <marco@paladinsec.co>, Mario <mario@paladinsec.co>, DeFiFoFum (@DeFiFoFum)
+author: Apeguru (@Apegurus), Marco De Vries <marco@paladinsec.co>, Mario <mario@paladinsec.co>, DeFiFoFum (@DeFiFoFum), Elliott Green (@elliott-green)
 discussions-to: https://ethereum-magicians.org/t/eip-5725-transferable-vesting-nft/11099
 status: Draft
 type: Standards Track
@@ -20,7 +20,7 @@ The following standard allows for the implementation of a standard API for NFT b
 ## Motivation
 
 Vesting contracts, including timelock contracts, lack a standard and unified interface, which results in diverse implementations of such contracts. Standardizing such contracts into a single interface would allow for the creation of an ecosystem of on- and off-chain tooling around these contracts. In addition, liquid vesting in the form of non-fungible assets can prove to be a huge improvement over traditional **Simple Agreement for Future Tokens** (SAFTs) or **Externally Owned Account** (EOA)-based vesting as it enables transferability and the ability to attach metadata similar to the existing functionality offered by with traditional NFTs.
-  
+
 Such a standard will not only provide a much-needed [EIP-20](./eip-20.md) token lock standard, but will also enable the creation of secondary marketplaces tailored for semi-liquid SAFTs.
 
 This standard also allows for a variety of different vesting curves to be implement easily.
@@ -34,21 +34,20 @@ These curves could represent:
 
 ### Use Cases
 
-1. A framework  to release tokens over a set period of time that can be used to build many kinds of NFT financial products such as bonds, treasury bills, and many others.
+1. A framework to release tokens over a set period of time that can be used to build many kinds of NFT financial products such as bonds, treasury bills, and many others.
 2. Replicating SAFT contracts in a standardized form of semi-liquid vesting NFT assets.
-    - SAFTs are generally off-chain, while today's on-chain versions are mainly address-based, which makes distributing vesting shares to many representatives difficult. Standardization simplifies this convoluted process.
+   - SAFTs are generally off-chain, while today's on-chain versions are mainly address-based, which makes distributing vesting shares to many representatives difficult. Standardization simplifies this convoluted process.
 3. Providing a path for the standardization of vesting and token timelock contracts.
-    - There are many such contracts in the wild and most of them differ in both interface and implementation.
+   - There are many such contracts in the wild and most of them differ in both interface and implementation.
 4. NFT marketplaces dedicated to vesting NFTs.
-    - Whole new sets of interfaces and analytics could be created from a common standard for token vesting NFTs.
+   - Whole new sets of interfaces and analytics could be created from a common standard for token vesting NFTs.
 5. Integrating vesting NFTs into services like Safe Wallet.
-    - A standard would mean services like Safe Wallet could more easily and uniformly support interactions with these types of contracts inside of a multisig contract.
+   - A standard would mean services like Safe Wallet could more easily and uniformly support interactions with these types of contracts inside of a multisig contract.
 6. Enable standardized fundraising implementations and general fundraising that sell vesting tokens (eg. SAFTs) in a more transparent manner.
 7. Allows tools, front-end apps, aggregators, etc. to show a more holistic view of the vesting tokens and the properties available to users.
-    - Currently, every project needs to write their own visualization of the vesting schedule of their vesting assets. If this is standardized, third-party tools could be developed to aggregate all vesting NFTs from all projects for the user, display their schedules and allow the user to take aggregated vesting actions.
-    - Such tooling can easily discover compliance through the [EIP-165](./eip-165.md) `supportsInterface(InterfaceID)` check.
+   - Currently, every project needs to write their own visualization of the vesting schedule of their vesting assets. If this is standardized, third-party tools could be developed to aggregate all vesting NFTs from all projects for the user, display their schedules and allow the user to take aggregated vesting actions.
+   - Such tooling can easily discover compliance through the [EIP-165](./eip-165.md) `supportsInterface(InterfaceID)` check.
 8. Makes it easier for a single wrapping implementation to be used across all vesting standards that defines multiple recipients, periodic renting of vesting tokens etc.
-
 
 ## Specification
 
@@ -56,97 +55,112 @@ The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL 
 
 ```solidity
 // SPDX-License-Identifier: CC0-1.0
+// SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.0;
-import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import '@openzeppelin/contracts/token/ERC721/IERC721.sol';
 
 /**
  * @title Non-Fungible Vesting Token Standard
- * @notice A non-fungible token standard used to vest tokens (EIP-20 or otherwise) over a vesting release curve
+ * @notice A non-fungible token standard used to vest ERC-20 tokens over a vesting release curve
  *  scheduled using timestamps.
  * @dev Because this standard relies on timestamps for the vesting schedule, it's important to keep track of the
  *  tokens claimed per Vesting NFT so that a user cannot withdraw more tokens than alloted for a specific Vesting NFT.
  */
 interface IERC5725 is IERC721 {
-    /**
-     *  This event is emitted when the payout is claimed through the claim function
-     *  @param tokenId the NFT tokenId of the assets being claimed.
-     *  @param recipient The address which is receiving the payout.
-     *  @param claimAmount The amount of tokens being claimed.
-     */
-    event PayoutClaimed(uint256 indexed tokenId, address indexed recipient, uint256 claimAmount);
+  /**
+   *  This event is emitted when the payout is claimed through the claim function
+   *  @param tokenId the NFT tokenId of the assets being claimed.
+   *  @param recipient The address which is receiving the payout.
+   *  @param claimAmount The amount of tokens being claimed.
+   */
+  event PayoutClaimed(
+    uint256 indexed tokenId,
+    address indexed recipient,
+    uint256 claimAmount
+  );
 
-    /**
-     * @notice Claim the pending payout for the NFT
-     * @dev MUST grant the claimablePayout value at the time of claim being called
-     * MUST revert if not called by the token owner or approved users
-     * MUST emit PayoutClaimed
-     * SHOULD revert if there is nothing to claim
-     * @param tokenId The NFT token id
-     */
-    function claim(uint256 tokenId) external;
+  /**
+   * @notice Claim the pending payout for the NFT
+   * @dev MUST grant the claimablePayout value at the time of claim being called to `msg.sender`
+   * MUST revert if not called by the token owner or approved users
+   * MUST emit PayoutClaimed
+   * SHOULD revert if there is nothing to claim
+   * @param tokenId The NFT token id
+   */
+  function claim(uint256 tokenId) external;
 
-    /**
-     * @notice Number of tokens for the NFT which have been claimed at the current timestamp
-     * @param tokenId The NFT token id
-     * @return payout The total amount of payout tokens claimed for this NFT 
-     */
-    function claimedPayout(uint256 tokenId) external view returns (uint256 payout);
+  /**
+   * @notice Number of tokens for the NFT which have been claimed at the current timestamp
+   * @param tokenId The NFT token id
+   * @return payout The total amount of payout tokens claimed for this NFT
+   */
+  function claimedPayout(
+    uint256 tokenId
+  ) external view returns (uint256 payout);
 
-    /**
-     * @notice Number of tokens for the NFT which can be claimed at the current timestamp
-     * @dev It is RECOMMENDED that this is calculated as the `vestedPayout()` subtracted from `payoutClaimed()`.
-     * @param tokenId The NFT token id
-     * @return payout The amount of unlocked payout tokens for the NFT which have not yet been claimed
-     */
-    function claimablePayout(uint256 tokenId) external view returns (uint256 payout);
+  /**
+   * @notice Number of tokens for the NFT which can be claimed at the current timestamp
+   * @dev It is RECOMMENDED that this is calculated as the `vestedPayout()` subtracted from `payoutClaimed()`.
+   * @param tokenId The NFT token id
+   * @return payout The amount of unlocked payout tokens for the NFT which have not yet been claimed
+   */
+  function claimablePayout(
+    uint256 tokenId
+  ) external view returns (uint256 payout);
 
-    /**
-     * @notice Total amount of tokens which have been vested at the current timestamp.
-     *   This number also includes vested tokens which have been claimed.
-     * @dev It is RECOMMENDED that this function calls `vestedPayoutAtTime` with
-     *   `block.timestamp` as the `timestamp` parameter.
-     * @param tokenId The NFT token id
-     * @return payout Total amount of tokens which have been vested at the current timestamp.
-     */
-    function vestedPayout(uint256 tokenId) external view returns (uint256 payout);
+  /**
+   * @notice Total amount of tokens which have been vested at the current timestamp.
+   *   This number also includes vested tokens which have been claimed.
+   * @dev It is RECOMMENDED that this function calls `vestedPayoutAtTime` with
+   *   `block.timestamp` as the `timestamp` parameter.
+   * @param tokenId The NFT token id
+   * @return payout Total amount of tokens which have been vested at the current timestamp.
+   */
+  function vestedPayout(uint256 tokenId) external view returns (uint256 payout);
 
-    /**
-     * @notice Total amount of vested tokens at the provided timestamp.
-     *   This number also includes vested tokens which have been claimed.
-     * @dev `timestamp` MAY be both in the future and in the past.
-     * Zero MUST be returned if the timestamp is before the token was minted.
-     * @param tokenId The NFT token id
-     * @param timestamp The timestamp to check on, can be both in the past and the future
-     * @return payout Total amount of tokens which have been vested at the provided timestamp
-     */
-    function vestedPayoutAtTime(uint256 tokenId, uint256 timestamp) external view returns (uint256 payout);
+  /**
+   * @notice Total amount of vested tokens at the provided timestamp.
+   *   This number also includes vested tokens which have been claimed.
+   * @dev `timestamp` MAY be both in the future and in the past.
+   * Zero MUST be returned if the timestamp is before the token was minted.
+   * @param tokenId The NFT token id
+   * @param timestamp The timestamp to check on, can be both in the past and the future
+   * @return payout Total amount of tokens which have been vested at the provided timestamp
+   */
+  function vestedPayoutAtTime(
+    uint256 tokenId,
+    uint256 timestamp
+  ) external view returns (uint256 payout);
 
-    /**
-     * @notice Number of tokens for an NFT which are currently vesting.
-     * @dev The sum of vestedPayout and vestingPayout SHOULD always be the total payout.
-     * @param tokenId The NFT token id
-     * @return payout The number of tokens for the NFT which are vesting until a future date.
-     */
-    function vestingPayout(uint256 tokenId) external view returns (uint256 payout);
+  /**
+   * @notice Number of tokens for an NFT which are currently vesting.
+   * @dev The sum of vestedPayout and vestingPayout SHOULD always be the total payout.
+   * @param tokenId The NFT token id
+   * @return payout The number of tokens for the NFT which are vesting until a future date.
+   */
+  function vestingPayout(
+    uint256 tokenId
+  ) external view returns (uint256 payout);
 
-    /**
-     * @notice The start and end timestamps for the vesting of the provided NFT
-     * MUST return the timestamp where no further increase in vestedPayout occurs for `vestingEnd`.
-     * @param tokenId The NFT token id
-     * @return vestingStart The beginning of the vesting as a unix timestamp
-     * @return vestingEnd The ending of the vesting as a unix timestamp
-     */
-    function vestingPeriod(uint256 tokenId) external view returns (uint256 vestingStart, uint256 vestingEnd);
+  /**
+   * @notice The start and end timestamps for the vesting of the provided NFT
+   * MUST return the timestamp where no further increase in vestedPayout occurs for `vestingEnd`.
+   * @param tokenId The NFT token id
+   * @return vestingStart The beginning of the vesting as a unix timestamp
+   * @return vestingEnd The ending of the vesting as a unix timestamp
+   */
+  function vestingPeriod(
+    uint256 tokenId
+  ) external view returns (uint256 vestingStart, uint256 vestingEnd);
 
-    /**
-     * @notice Token which is used to pay out the vesting claims
-     * @param tokenId The NFT token id
-     * @return token The token which is used to pay out the vesting claims
-     */
-    function payoutToken(uint256 tokenId) external view returns (address token);
+  /**
+   * @notice Token which is used to pay out the vesting claims
+   * @param tokenId The NFT token id
+   * @return token The token which is used to pay out the vesting claims
+   */
+  function payoutToken(uint256 tokenId) external view returns (address token);
 }
 ```
-
 
 ## Rationale
 
@@ -164,10 +178,9 @@ These are base terms used around the specification which function names and defi
 
 **`vestingPayout` + `vestedPayout`**
 
-`vestingPayout(uint256 tokenId)` and `vestedPayout(uint256 tokenId)` add up to the total number of tokens which can be claimed by the end of of the vesting schedule. This is also equal to `vestedPayoutAtTime(uint256 tokenId, uint256 timestamp)` with `type(uint256).max` as the `timestamp`.  
+`vestingPayout(uint256 tokenId)` and `vestedPayout(uint256 tokenId)` add up to the total number of tokens which can be claimed by the end of of the vesting schedule. This is also equal to `vestedPayoutAtTime(uint256 tokenId, uint256 timestamp)` with `type(uint256).max` as the `timestamp`.
 
-The rationale for this is to guarantee that the tokens `vested` and tokens `vesting` are always in sync. The intent is that the vesting curves created are deterministic across the `vestingPeriod`. This creates useful opportunities for integration with these NFTs. For example: A vesting schedule can be iterated through and a vesting curve could be visualized, either on-chain or off-chain. 
-
+The rationale for this is to guarantee that the tokens `vested` and tokens `vesting` are always in sync. The intent is that the vesting curves created are deterministic across the `vestingPeriod`. This creates useful opportunities for integration with these NFTs. For example: A vesting schedule can be iterated through and a vesting curve could be visualized, either on-chain or off-chain.
 
 **`vestedPayout` vs `claimedPayout` & `claimablePayout`**
 
@@ -180,11 +193,12 @@ vestedPayout - claimedPayout - claimablePayout = lockedPayout
 - `claimablePayout(uint256 tokenId)` provides the amount of payout tokens which can be unlocked at the current `timestamp`.
 
 The rationale for providing three functions is to support a number of features:
+
 1. The return of `vestedPayout(uint256 tokenId)` will always match the return of `vestedPayoutAtTime(uint256 tokenId, uint256 timestamp)` with `block.timestamp` as the `timestamp`.
 2. `claimablePayout(uint256 tokenId)` can be used to easily see the current payout unlock amount and allow for unlock cliffs by returning zero until a `timestamp` has been passed.
 3. `claimedPayout(uint256 tokenId)` is helpful to see tokens unlocked from an NFT and it is also necessary for the calculation of vested-but-locked payout tokens: `vestedPayout - claimedPayout - claimablePayout = lockedPayout`. This would depend on how the vesting curves are configured by the an implementation of this standard.
 
-`vestedPayoutAtTime(uint256 tokenId, uint256 timestamp)` provides functionality to iterate through the `vestingPeriod(uint256 tokenId)` and provide a visual of the release curve. The intent is that release curves are created which makes `vestedPayoutAtTime(uint256 tokenId, uint256 timestamp)` deterministic.  
+`vestedPayoutAtTime(uint256 tokenId, uint256 timestamp)` provides functionality to iterate through the `vestingPeriod(uint256 tokenId)` and provide a visual of the release curve. The intent is that release curves are created which makes `vestedPayoutAtTime(uint256 tokenId, uint256 timestamp)` deterministic.
 
 ### Timestamps
 
@@ -194,15 +208,14 @@ The `timestamp` makes cross chain integration easy, but internally, the referenc
 
 ### Limitation of Scope
 
-- **Historical claims**: While historical vesting schedules can be determined on-chain with `vestedPayoutAtTime(uint256 tokenId, uint256 timestamp)`, historical claims would need to be calculated through historical transaction data. Most likely querying for `PayoutClaimed` events to build a historical graph. 
+- **Historical claims**: While historical vesting schedules can be determined on-chain with `vestedPayoutAtTime(uint256 tokenId, uint256 timestamp)`, historical claims would need to be calculated through historical transaction data. Most likely querying for `PayoutClaimed` events to build a historical graph.
 
 ### Extension Possibilities
 
 These feature are not supported by the standard as is, but the standard could be extended to support these more advanced features.
 
 - **Custom Vesting Curves**: This standard intends on returning deterministic `vesting` values given NFT `tokenId` and a **timestamp** as inputs. This is intentional as it provides for flexibility in how the vesting curves work under the hood which doesn't constrain projects who intend on building a complex smart contract vesting architecture.
-- **Beneficiary**: This standard could be extended to provide for a `beneficiary` address who may `claim` unlocked tokens.
-- **NFT Rentals**: Further complex DeFi tools can be created if vesting NFTs could be rented. 
+- **NFT Rentals**: Further complex DeFi tools can be created if vesting NFTs could be rented.
 
 This is done intentionally to keep the base standard simple. These features can and likely will be added through extensions of this standard.
 

--- a/EIP-draft.md
+++ b/EIP-draft.md
@@ -2,7 +2,7 @@
 eip: 5725
 title: Transferable Vesting NFT
 description: An interface for transferable vesting NFTs which release underlying tokens over time.
-author: Apeguru (@Apegurus), Marco De Vries <marco@paladinsec.co>, Mario <mario@paladinsec.co>, DeFiFoFum (@DeFiFoFum)
+author: Apeguru (@Apegurus), Marco De Vries <marco@paladinsec.co>, Mario <mario@paladinsec.co>, DeFiFoFum (@DeFiFoFum), Elliott Green (@elliott-green)
 discussions-to: https://ethereum-magicians.org/t/eip-5725-transferable-vesting-nft/11099
 status: Draft
 type: Standards Track
@@ -20,7 +20,7 @@ The following standard allows for the implementation of a standard API for NFT b
 ## Motivation
 
 Vesting contracts, including timelock contracts, lack a standard and unified interface, which results in diverse implementations of such contracts. Standardizing such contracts into a single interface would allow for the creation of an ecosystem of on- and off-chain tooling around these contracts. In addition, liquid vesting in the form of non-fungible assets can prove to be a huge improvement over traditional **Simple Agreement for Future Tokens** (SAFTs) or **Externally Owned Account** (EOA)-based vesting as it enables transferability and the ability to attach metadata similar to the existing functionality offered by with traditional NFTs.
-  
+
 Such a standard will not only provide a much-needed [EIP-20](./eip-20.md) token lock standard, but will also enable the creation of secondary marketplaces tailored for semi-liquid SAFTs.
 
 This standard also allows for a variety of different vesting curves to be implement easily.
@@ -34,21 +34,20 @@ These curves could represent:
 
 ### Use Cases
 
-1. A framework  to release tokens over a set period of time that can be used to build many kinds of NFT financial products such as bonds, treasury bills, and many others.
+1. A framework to release tokens over a set period of time that can be used to build many kinds of NFT financial products such as bonds, treasury bills, and many others.
 2. Replicating SAFT contracts in a standardized form of semi-liquid vesting NFT assets.
-    - SAFTs are generally off-chain, while today's on-chain versions are mainly address-based, which makes distributing vesting shares to many representatives difficult. Standardization simplifies this convoluted process.
+   - SAFTs are generally off-chain, while today's on-chain versions are mainly address-based, which makes distributing vesting shares to many representatives difficult. Standardization simplifies this convoluted process.
 3. Providing a path for the standardization of vesting and token timelock contracts.
-    - There are many such contracts in the wild and most of them differ in both interface and implementation.
+   - There are many such contracts in the wild and most of them differ in both interface and implementation.
 4. NFT marketplaces dedicated to vesting NFTs.
-    - Whole new sets of interfaces and analytics could be created from a common standard for token vesting NFTs.
+   - Whole new sets of interfaces and analytics could be created from a common standard for token vesting NFTs.
 5. Integrating vesting NFTs into services like Gnosis Safe.
-    - A standard would mean services like Gnosis Safe could more easily and uniformly support interactions with these types of contracts inside of a multisig contract.
+   - A standard would mean services like Gnosis Safe could more easily and uniformly support interactions with these types of contracts inside of a multisig contract.
 6. Enable standardized fundraising implementations and general fundraising that sell vesting tokens (eg. SAFTs) in a more transparent manner.
 7. Allows tools, front-end apps, aggregators, etc. to show a more holistic view of the vesting tokens and the properties available to users.
-    - Currently, every project needs to write their own visualization of the vesting schedule of their vesting assets. If this is standardized, third-party tools could be developed aggregate all vesting NFTs from all projects for the user, display their schedules and allow the user to take aggregated vesting actions.
-    - Such tooling can easily discover compliance through the [EIP-165](./eip-165.md) `supportsInterface(InterfaceID)` check.
+   - Currently, every project needs to write their own visualization of the vesting schedule of their vesting assets. If this is standardized, third-party tools could be developed aggregate all vesting NFTs from all projects for the user, display their schedules and allow the user to take aggregated vesting actions.
+   - Such tooling can easily discover compliance through the [EIP-165](./eip-165.md) `supportsInterface(InterfaceID)` check.
 8. Makes it easier for a single wrapping implementation to be used across all vesting standards that defines multiple recipients, periodic renting of vesting tokens etc.
-
 
 ## Specification
 
@@ -57,7 +56,7 @@ The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL 
 ```solidity
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.0;
-import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import '@openzeppelin/contracts/token/ERC721/IERC721.sol';
 
 /**
  * @title Non-Fungible Vesting Token Standard
@@ -67,86 +66,134 @@ import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
  *  tokens claimed per Vesting NFT so that a user cannot withdraw more tokens than alloted for a specific Vesting NFT.
  */
 interface IERC5725 is IERC721 {
-    /**
-     *  This event is emitted when the payout is claimed through the claim function
-     *  @param tokenId the NFT tokenId of the assets being claimed.
-     *  @param recipient The address which is receiving the payout.
-     *  @param claimAmount The amount of tokens being claimed.
-     */
-    event PayoutClaimed(uint256 indexed tokenId, address indexed recipient, uint256 claimAmount);
+  /**
+   *  This event is emitted when the payout is claimed through the claim function
+   *  @param tokenId the NFT tokenId of the assets being claimed.
+   *  @param recipient The address which is receiving the payout.
+   *  @param claimAmount The amount of tokens being claimed.
+   */
+  event PayoutClaimed(
+    uint256 indexed tokenId,
+    address indexed recipient,
+    uint256 claimAmount
+  );
 
-    /**
-     * @notice Claim the pending payout for the NFT
-     * @dev MUST grant the claimablePayout value at the time of claim being called
-     * MUST revert if not called by the token owner or approved users
-     * MUST emit PayoutClaimed
-     * SHOULD revert if there is nothing to claim
-     * @param tokenId The NFT token id
-     */
-    function claim(uint256 tokenId) external;
+  /**
+   * @notice Claim the pending payout for the NFT
+   * @dev MUST grant the claimablePayout value at the time of claim being called
+   * MUST revert if not called by the token owner or approved users
+   * MUST emit PayoutClaimed
+   * SHOULD revert if there is nothing to claim
+   * @param tokenId The NFT token id
+   */
+  function claim(uint256 tokenId) external;
 
-    /**
-     * @notice Number of tokens for the NFT which have been claimed at the current timestamp
-     * @param tokenId The NFT token id
-     * @return payout The total amount of payout tokens claimed for this NFT 
-     */
-    function claimedPayout(uint256 tokenId) external view returns (uint256 payout);
+  /**
+   * @notice Number of tokens for the NFT which have been claimed at the current timestamp
+   * @param tokenId The NFT token id
+   * @return payout The total amount of payout tokens claimed for this NFT
+   */
+  function claimedPayout(
+    uint256 tokenId
+  ) external view returns (uint256 payout);
 
-    /**
-     * @notice Number of tokens for the NFT which can be claimed at the current timestamp
-     * @dev It is RECOMMENDED that this is calculated as the `vestedPayout()` subtracted from `payoutClaimed()`.
-     * @param tokenId The NFT token id
-     * @return payout The amount of unlocked payout tokens for the NFT which have not yet been claimed
-     */
-    function claimablePayout(uint256 tokenId) external view returns (uint256 payout);
+  /**
+   * @notice Number of tokens for the NFT which can be claimed at the current timestamp
+   * @dev It is RECOMMENDED that this is calculated as the `vestedPayout()` subtracted from `payoutClaimed()`.
+   * @param tokenId The NFT token id
+   * @return payout The amount of unlocked payout tokens for the NFT which have not yet been claimed
+   */
+  function claimablePayout(
+    uint256 tokenId
+  ) external view returns (uint256 payout);
 
-    /**
-     * @notice Total amount of tokens which have been vested at the current timestamp.
-     *   This number also includes vested tokens which have been claimed.
-     * @dev It is RECOMMENDED that this function calls `vestedPayoutAtTime` with
-     *   `block.timestamp` as the `timestamp` parameter.
-     * @param tokenId The NFT token id
-     * @return payout Total amount of tokens which have been vested at the current timestamp.
-     */
-    function vestedPayout(uint256 tokenId) external view returns (uint256 payout);
+  /**
+   * @notice Total amount of tokens which have been vested at the current timestamp.
+   *   This number also includes vested tokens which have been claimed.
+   * @dev It is RECOMMENDED that this function calls `vestedPayoutAtTime` with
+   *   `block.timestamp` as the `timestamp` parameter.
+   * @param tokenId The NFT token id
+   * @return payout Total amount of tokens which have been vested at the current timestamp.
+   */
+  function vestedPayout(uint256 tokenId) external view returns (uint256 payout);
 
-    /**
-     * @notice Total amount of vested tokens at the provided timestamp.
-     *   This number also includes vested tokens which have been claimed.
-     * @dev `timestamp` MAY be both in the future and in the past.
-     * Zero MUST be returned if the timestamp is before the token was minted.
-     * @param tokenId The NFT token id
-     * @param timestamp The timestamp to check on, can be both in the past and the future
-     * @return payout Total amount of tokens which have been vested at the provided timestamp
-     */
-    function vestedPayoutAtTime(uint256 tokenId, uint256 timestamp) external view returns (uint256 payout);
+  /**
+   * @notice Total amount of vested tokens at the provided timestamp.
+   *   This number also includes vested tokens which have been claimed.
+   * @dev `timestamp` MAY be both in the future and in the past.
+   * Zero MUST be returned if the timestamp is before the token was minted.
+   * @param tokenId The NFT token id
+   * @param timestamp The timestamp to check on, can be both in the past and the future
+   * @return payout Total amount of tokens which have been vested at the provided timestamp
+   */
+  function vestedPayoutAtTime(
+    uint256 tokenId,
+    uint256 timestamp
+  ) external view returns (uint256 payout);
 
-    /**
-     * @notice Number of tokens for an NFT which are currently vesting.
-     * @dev The sum of vestedPayout and vestingPayout SHOULD always be the total payout.
-     * @param tokenId The NFT token id
-     * @return payout The number of tokens for the NFT which are vesting until a future date.
-     */
-    function vestingPayout(uint256 tokenId) external view returns (uint256 payout);
+  /**
+   * @notice Number of tokens for an NFT which are currently vesting.
+   * @dev The sum of vestedPayout and vestingPayout SHOULD always be the total payout.
+   * @param tokenId The NFT token id
+   * @return payout The number of tokens for the NFT which are vesting until a future date.
+   */
+  function vestingPayout(
+    uint256 tokenId
+  ) external view returns (uint256 payout);
 
-    /**
-     * @notice The start and end timestamps for the vesting of the provided NFT
-     * MUST return the timestamp where no further increase in vestedPayout occurs for `vestingEnd`.
-     * @param tokenId The NFT token id
-     * @return vestingStart The beginning of the vesting as a unix timestamp
-     * @return vestingEnd The ending of the vesting as a unix timestamp
-     */
-    function vestingPeriod(uint256 tokenId) external view returns (uint256 vestingStart, uint256 vestingEnd);
+  /**
+   * @notice The start and end timestamps for the vesting of the provided NFT
+   * MUST return the timestamp where no further increase in vestedPayout occurs for `vestingEnd`.
+   * @param tokenId The NFT token id
+   * @return vestingStart The beginning of the vesting as a unix timestamp
+   * @return vestingEnd The ending of the vesting as a unix timestamp
+   */
+  function vestingPeriod(
+    uint256 tokenId
+  ) external view returns (uint256 vestingStart, uint256 vestingEnd);
 
-    /**
-     * @notice Token which is used to pay out the vesting claims
-     * @param tokenId The NFT token id
-     * @return token The token which is used to pay out the vesting claims
-     */
-    function payoutToken(uint256 tokenId) external view returns (address token);
+  /**
+   * @notice Token which is used to pay out the vesting claims
+   * @param tokenId The NFT token id
+   * @return token The token which is used to pay out the vesting claims
+   */
+  function payoutToken(uint256 tokenId) external view returns (address token);
+
+  /**
+   * @notice Atomically increases the allowance granted to `spender` by the caller.
+   * @dev `spender` cannot be the zero address.
+   * @dev Emits an {ClaimApproval} event indicating the updated allowance value.
+   * @param spender The `spender` to be granted allowance.
+   * @param addedValue The allowance granted to `spender`.
+   */
+  function increaseClaimAllowance(address spender, uint256 addedValue) external;
+
+  /**
+   * @notice Atomically decreases the allowance granted to `spender` by the caller.
+   * @dev `spender` cannot be the zero address.
+   * @dev Emits an {ClaimApproval} event indicating the updated allowance value.
+   * @param spender The `spender` to have allowance reduced.
+   * @param subtractedValue The allowance decreased from `spender`.
+   */
+  function decreaseClaimAllowance(
+    address spender,
+    uint256 subtractedValue
+  ) external;
+
+  /**
+   * @notice Total amount of allowance granted to a particular `spender`.
+   * @dev `owner` cannot be the zero address.
+   * @dev `spender` cannot be the zero address.
+   * @param owner The allowance giver.
+   * @param spender The allowance sender.
+   * @return result The number of tokens permitted to be spent by the `spender`.
+   */
+  function allowance(
+    address owner,
+    address spender
+  ) external view returns (uint256 result);
 }
 ```
-
 
 ## Rationale
 
@@ -164,10 +211,9 @@ These are base terms used around the specification which function names and defi
 
 **`vestingPayout` + `vestedPayout`**
 
-`vestingPayout(uint256 tokenId)` and `vestedPayout(uint256 tokenId)` add up to the total number of tokens which can be claimed by the end of of the vesting schedule. This is also equal to `vestedPayoutAtTime(uint256 tokenId, uint256 timestamp)` with `type(uint256).max` as the `timestamp`.  
+`vestingPayout(uint256 tokenId)` and `vestedPayout(uint256 tokenId)` add up to the total number of tokens which can be claimed by the end of of the vesting schedule. This is also equal to `vestedPayoutAtTime(uint256 tokenId, uint256 timestamp)` with `type(uint256).max` as the `timestamp`.
 
-The rationale for this is to guarantee that the tokens `vested` and tokens `vesting` are always in sync. The intent is that the vesting curves created are deterministic across the `vestingPeriod`. This creates useful opportunities for integration with these NFTs. For example: A vesting schedule can be iterated through and a vesting curve could be visualized, either on-chain or off-chain. 
-
+The rationale for this is to guarantee that the tokens `vested` and tokens `vesting` are always in sync. The intent is that the vesting curves created are deterministic across the `vestingPeriod`. This creates useful opportunities for integration with these NFTs. For example: A vesting schedule can be iterated through and a vesting curve could be visualized, either on-chain or off-chain.
 
 **`vestedPayout` vs `claimedPayout` & `claimablePayout`**
 
@@ -180,11 +226,16 @@ vestedPayout - claimedPayout - claimablePayout = lockedPayout
 - `claimablePayout(uint256 tokenId)` provides the amount of payout tokens which can be unlocked at the current `timestamp`.
 
 The rationale for providing three functions is to support a number of features:
+
 1. The return of `vestedPayout(uint256 tokenId)` will always match the return of `vestedPayoutAtTime(uint256 tokenId, uint256 timestamp)` with `block.timestamp` as the `timestamp`.
 2. `claimablePayout(uint256 tokenId)` can be used to easily see the current payout unlock amount and allow for unlock cliffs by returning zero until a `timestamp` has been passed.
 3. `claimedPayout(uint256 tokenId)` is helpful to see tokens unlocked from an NFT and it is also necessary for the calculation of vested-but-locked payout tokens: `vestedPayout - claimedPayout - claimablePayout = lockedPayout`. This would depend on how the vesting curves are configured by the an implementation of this standard.
 
-`vestedPayoutAtTime(uint256 tokenId, uint256 timestamp)` provides functionality to iterate through the `vestingPeriod(uint256 tokenId)` and provide a visual of the release curve. The intent is that release curves are created which makes `vestedPayoutAtTime(uint256 tokenId, uint256 timestamp)` deterministic.  
+`vestedPayoutAtTime(uint256 tokenId, uint256 timestamp)` provides functionality to iterate through the `vestingPeriod(uint256 tokenId)` and provide a visual of the release curve. The intent is that release curves are created which makes `vestedPayoutAtTime(uint256 tokenId, uint256 timestamp)` deterministic.
+
+### Claim Allowances
+
+ERC-5725 provides an allowance mechanism for the owner of a token to set a `spender` with an `amount` which may call `claim(tokenId)` on behalf of the owner. The `amount` can be claimed across multiple `tokenIds`. The allowance `amount` is not reset if the owner transfers all of their NFT's away, the allowance maybe spent in the future if owner reaquires a token.
 
 ### Timestamps
 
@@ -194,7 +245,7 @@ The `timestamp` makes cross chain integration easy, but internally, the referenc
 
 ### Limitation of Scope
 
-- **Historical claims**: While historical vesting schedules can be determined on-chain with `vestedPayoutAtTime(uint256 tokenId, uint256 timestamp)`, historical claims would need to be calculated through historical transaction data. Most likely querying for `PayoutClaimed` events to build a historical graph. 
+- **Historical claims**: While historical vesting schedules can be determined on-chain with `vestedPayoutAtTime(uint256 tokenId, uint256 timestamp)`, historical claims would need to be calculated through historical transaction data. Most likely querying for `PayoutClaimed` events to build a historical graph.
 
 ### Extension Possibilities
 
@@ -202,7 +253,7 @@ These feature are not supported by the standard as is, but the standard could be
 
 - **Custom Vesting Curves**: This standard intends on returning deterministic `vesting` values given NFT `tokenId` and a **timestamp** as inputs. This is intentional as it provides for flexibility in how the vesting curves work under the hood which doesn't constrain projects who intend on building a complex smart contract vesting architecture.
 - **Beneficiary**: This standard could be extended to provide for a `beneficiary` address who may `claim` unlocked tokens.
-- **NFT Rentals**: Further complex DeFi tool can be created if vesting NFTs could be rented. 
+- **NFT Rentals**: Further complex DeFi tool can be created if vesting NFTs could be rented.
 
 This is done intentionally to keep the base standard simple. These features can and likely will be added through extensions of this standard.
 

--- a/EIP-draft.md
+++ b/EIP-draft.md
@@ -55,7 +55,7 @@ The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL 
 
 ```solidity
 // SPDX-License-Identifier: CC0-1.0
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.17;
 import '@openzeppelin/contracts/token/ERC721/IERC721.sol';
 
 /**

--- a/contracts/ERC5725.sol
+++ b/contracts/ERC5725.sol
@@ -53,6 +53,20 @@ abstract contract ERC5725 is IERC5725, ERC721 {
     /**
      * @dev See {IERC5725}.
      */
+    function increaseClaimAllowance(address spender, uint256 addedValue) external override(IERC5725) {
+        _setClaimAllowance(msg.sender, spender, _allowances[msg.sender][spender] + addedValue);
+    }
+
+    /**
+     * @dev See {IERC5725}.
+     */
+    function decreaseClaimAllowance(address spender, uint256 subtractedValue) external override(IERC5725) {
+        _setClaimAllowance(msg.sender, spender, _allowances[msg.sender][spender] - subtractedValue);
+    }
+
+    /**
+     * @dev See {IERC5725}.
+     */
     function vestedPayout(uint256 tokenId) public view override(IERC5725) returns (uint256 payout) {
         return vestedPayoutAtTime(tokenId, block.timestamp);
     }
@@ -111,20 +125,6 @@ abstract contract ERC5725 is IERC5725, ERC721 {
     /**
      * @dev See {IERC5725}.
      */
-    function increaseClaimAllowance(address spender, uint256 addedValue) external override(IERC5725) {
-        _setClaimAllowance(msg.sender, spender, _allowances[msg.sender][spender] + addedValue);
-    }
-
-    /**
-     * @dev See {IERC5725}.
-     */
-    function decreaseClaimAllowance(address spender, uint256 subtractedValue) external override(IERC5725) {
-        _setClaimAllowance(msg.sender, spender, _allowances[msg.sender][spender] - subtractedValue);
-    }
-
-    /**
-     * @dev See {IERC5725}.
-     */
     function allowance(address owner, address spender) public view override(IERC5725) returns (uint256 result) {
         return _allowances[owner][spender];
     }
@@ -140,7 +140,7 @@ abstract contract ERC5725 is IERC5725, ERC721 {
     }
 
     /**
-     * @dev Internal function to spend a set allowance
+     * @dev Internal function to set a spendable allowance
      *
      * @param owner The owner of the token
      * @param spender The spender who is permitted to spend the allowance

--- a/contracts/ERC5725.sol
+++ b/contracts/ERC5725.sol
@@ -45,7 +45,9 @@ abstract contract ERC5725 is IERC5725, ERC721 {
     }
 
     /**
-     * @dev See {IERC5725}.
+     * @dev Sets a global `operator` with permission to manage all tokens owned by the current `msg.sender`.
+     * @param operator The address to let manage all tokens.
+     * @param approved A boolean indicating whether the spender is approved to claim for all tokens.
      */
     function setClaimApprovalForAll(address operator, bool approved) external {
         _setClaimApprovalForAll(operator, approved);
@@ -53,7 +55,10 @@ abstract contract ERC5725 is IERC5725, ERC721 {
     }
 
     /**
-     * @dev See {IERC5725}.
+     * @dev Sets a tokenId `operator` with permission to manage a single `tokenId` owned by the `msg.sender`.
+     * @param operator The address to let manage a single `tokenId`.
+     * @param tokenId the `tokenId` to be managed.
+     * @param approved A boolean indicating whether the spender is approved to claim for all tokens.
      */
     function setClaimApproval(address operator, uint256 tokenId, bool approved) external validToken(tokenId) {
         _setClaimApproval(operator, tokenId);
@@ -120,7 +125,7 @@ abstract contract ERC5725 is IERC5725, ERC721 {
 
     /**
      * @dev See {IERC165-supportsInterface}.
-     * IERC5725 interfaceId = 0xd707c82a
+     * IERC5725 interfaceId = 0x7c89676d
      */
     function supportsInterface(
         bytes4 interfaceId
@@ -129,14 +134,17 @@ abstract contract ERC5725 is IERC5725, ERC721 {
     }
 
     /**
-     * @dev See {IERC5725}.
+     * @dev Returns the operating address for a `tokenId`. If `tokenId` is not managed, then returns the zero address.
+     * @param tokenId The NFT `tokenId` to query for a `tokenId` manager.
      */
     function getClaimApproved(uint256 tokenId) public view returns (address operator) {
         return _tokenIdApprovals[tokenId];
     }
 
     /**
-     * @dev See {IERC5725}.
+     * @dev Returns true if `owner` has set `operator` to manage all `tokenId`s.
+     * @param owner The owner allowing `operator` to manage all `tokenId`s.
+     * @param operator The address who is given permission to spend tokens on behalf of the `owner`.
      */
     function isClaimApprovedForAll(address owner, address operator) public view returns (bool isClaimApproved) {
         return _operatorApprovals[owner][operator];
@@ -178,8 +186,8 @@ abstract contract ERC5725 is IERC5725, ERC721 {
     }
 
     /**
-     * @dev Internal hook to remove permissions to _tokenIdApprovals[tokenId]
-     *      Removes permissions when the tokenId is transferred, burnt, but not on mint.
+     * @dev Internal function to hook into {IERC721-_afterTokenTransfer}, when a token is being transferred.
+     * Removes permissions to _tokenIdApprovals[tokenId] when the tokenId is transferred, burnt, but not on mint.
      *
      * @param from The address from which the tokens are being transferred.
      * @param to The address to which the tokens are being transferred.

--- a/contracts/ERC5725.sol
+++ b/contracts/ERC5725.sol
@@ -133,6 +133,35 @@ abstract contract ERC5725 is IERC5725, ERC721 {
     }
 
     /**
+     * @dev See {IERC5725}.
+     */
+    function getClaimApproved(uint256 tokenId) public view override(IERC5725) returns (address operator) {
+        return _tokenIdApprovals[tokenId];
+    }
+
+    /**
+     * @dev See {IERC5725}.
+     */
+    function isClaimApprovedForAll(
+        address owner,
+        address operator
+    ) public view override(IERC5725) returns (bool isClaimApproved) {
+        return _operatorApprovals[owner][operator];
+    }
+
+    /**
+     * @dev Public view which returns true if the operator has permission to claim for `tokenId`
+     * @notice To remove permissions, set operator to zero address.
+     *
+     * @param operator The address that has permission for a `tokenId`.
+     * @param tokenId The NFT `tokenId`.
+     */
+    function isApprovedClaimOrOwner(address operator, uint256 tokenId) public view virtual returns (bool) {
+        address owner = ownerOf(tokenId);
+        return (operator == owner || isClaimApprovedForAll(owner, operator) || getClaimApproved(tokenId) == operator);
+    }
+
+    /**
      * @dev Internal function to set the operator status for a given owner to manage all `tokenId`s.
      * @notice To remove permissions, set approved to false.
      *
@@ -156,7 +185,8 @@ abstract contract ERC5725 is IERC5725, ERC721 {
     }
 
     /**
-     * @dev Internal hook to remove permissions to _tokenIdApprovals[tokenId] when the tokenId is transferred, burnt - but not on mint.
+     * @dev Internal hook to remove permissions to _tokenIdApprovals[tokenId]
+     *      Removes permissions when the tokenId is transferred, burnt, but not on mint.
      *
      * @param from The address from which the tokens are being transferred.
      * @param to The address to which the tokens are being transferred.
@@ -168,35 +198,6 @@ abstract contract ERC5725 is IERC5725, ERC721 {
         if (from != address(0)) {
             delete _tokenIdApprovals[firstTokenId];
         }
-    }
-
-    /**
-     * @dev Public view which returns true if the operator has permission to claim for `tokenId`
-     * @notice To remove permissions, set operator to zero address.
-     *
-     * @param operator The address that has permission for a `tokenId`.
-     * @param tokenId The NFT `tokenId`.
-     */
-    function isApprovedClaimOrOwner(address operator, uint256 tokenId) public view virtual returns (bool) {
-        address owner = ownerOf(tokenId);
-        return (operator == owner || isClaimApprovedForAll(owner, operator) || getClaimApproved(tokenId) == operator);
-    }
-
-    /**
-     * @dev See {IERC5725}.
-     */
-    function getClaimApproved(uint256 tokenId) public view override(IERC5725) returns (address operator) {
-        return _tokenIdApprovals[tokenId];
-    }
-
-    /**
-     * @dev See {IERC5725}.
-     */
-    function isClaimApprovedForAll(
-        address owner,
-        address operator
-    ) public view override(IERC5725) returns (bool isClaimApproved) {
-        return _operatorApprovals[owner][operator];
     }
 
     /**

--- a/contracts/ERC5725.sol
+++ b/contracts/ERC5725.sol
@@ -129,27 +129,6 @@ abstract contract ERC5725 is IERC5725, ERC721 {
         return _allowances[owner][spender];
     }
 
-    // owner cannot ever be 0x since it's sender
-    // spender maybe null
-    // value maybe 0, but wont overflow (0.8 safemaths)
-    function _setClaimAllowance(address owner, address spender, uint256 value) internal virtual {
-        if (spender == address(0)) {
-            revert("ERC5725: spender cannot be 0 address");
-        }
-        _allowances[owner][spender] = value;
-        emit ClaimApproval(owner, spender, value);
-    }
-
-    function _spendAllowance(address owner, address spender, uint256 value) internal virtual {
-        uint256 currentAllowance = allowance(owner, spender);
-        if (currentAllowance != type(uint256).max) {
-            if (currentAllowance < value) {
-                revert("ERC5725: insufficient allowance");
-            }
-            _allowances[owner][spender] = currentAllowance - value;
-        }
-    }
-
     /**
      * @dev See {IERC165-supportsInterface}.
      * IERC5725 interfaceId = 0xf316c058
@@ -158,6 +137,40 @@ abstract contract ERC5725 is IERC5725, ERC721 {
         bytes4 interfaceId
     ) public view virtual override(ERC721, IERC165) returns (bool supported) {
         return interfaceId == type(IERC5725).interfaceId || super.supportsInterface(interfaceId);
+    }
+
+    /**
+     * @dev Internal function to spend a set allowance
+     *
+     * @param owner The owner of the token
+     * @param spender The spender who is permitted to spend the allowance
+     * @param value The allowance to be set for spender
+     *
+     */
+    function _setClaimAllowance(address owner, address spender, uint256 value) internal virtual {
+        if (spender == address(0)) {
+            revert("ERC5725: spender cannot be 0 address");
+        }
+        _allowances[owner][spender] = value;
+        emit ClaimApproval(owner, spender, value);
+    }
+
+    /**
+     * @dev Internal function to spend a set allowance
+     *
+     * @param owner The owner of the token
+     * @param spender The spender who is claiming the allowance
+     * @param value The allowance to be spent by spender
+     *
+     */
+    function _spendAllowance(address owner, address spender, uint256 value) internal virtual {
+        uint256 currentAllowance = allowance(owner, spender);
+        if (currentAllowance != type(uint256).max) {
+            if (currentAllowance < value) {
+                revert("ERC5725: insufficient allowance");
+            }
+            _allowances[owner][spender] = currentAllowance - value;
+        }
     }
 
     /**

--- a/contracts/ERC5725.sol
+++ b/contracts/ERC5725.sol
@@ -47,7 +47,7 @@ abstract contract ERC5725 is IERC5725, ERC721 {
     /**
      * @dev See {IERC5725}.
      */
-    function setClaimApprovalForAll(address operator, bool approved) external override(IERC5725) {
+    function setClaimApprovalForAll(address operator, bool approved) external {
         _setClaimApprovalForAll(operator, approved);
         emit ClaimApprovalForAll(msg.sender, operator, approved);
     }
@@ -55,11 +55,7 @@ abstract contract ERC5725 is IERC5725, ERC721 {
     /**
      * @dev See {IERC5725}.
      */
-    function setClaimApproval(
-        address operator,
-        uint256 tokenId,
-        bool approved
-    ) external override(IERC5725) validToken(tokenId) {
+    function setClaimApproval(address operator, uint256 tokenId, bool approved) external validToken(tokenId) {
         _setClaimApproval(operator, tokenId);
         emit ClaimApproval(msg.sender, operator, tokenId, approved);
     }
@@ -135,17 +131,14 @@ abstract contract ERC5725 is IERC5725, ERC721 {
     /**
      * @dev See {IERC5725}.
      */
-    function getClaimApproved(uint256 tokenId) public view override(IERC5725) returns (address operator) {
+    function getClaimApproved(uint256 tokenId) public view returns (address operator) {
         return _tokenIdApprovals[tokenId];
     }
 
     /**
      * @dev See {IERC5725}.
      */
-    function isClaimApprovedForAll(
-        address owner,
-        address operator
-    ) public view override(IERC5725) returns (bool isClaimApproved) {
+    function isClaimApprovedForAll(address owner, address operator) public view returns (bool isClaimApproved) {
         return _operatorApprovals[owner][operator];
     }
 

--- a/contracts/ERC5725.sol
+++ b/contracts/ERC5725.sol
@@ -39,7 +39,6 @@ abstract contract ERC5725 is IERC5725, ERC721 {
         uint256 amountClaimed = claimablePayout(tokenId);
         require(amountClaimed > 0, "ERC5725: No pending payout");
 
-        // If the caller is not the owner, spend the allowance
         if (ownerOf(tokenId) != msg.sender) {
             _spendAllowance(ownerOf(tokenId), msg.sender, amountClaimed);
         }

--- a/contracts/IERC5725.sol
+++ b/contracts/IERC5725.sol
@@ -20,7 +20,7 @@ interface IERC5725 is IERC721 {
 
     /**
      * @notice Claim the pending payout for the NFT
-     * @dev MUST grant the claimablePayout value at the time of claim being called to msg.sender
+     * @dev MUST grant the claimablePayout value at the time of claim being called to `msg.sender`
      * MUST revert if not called by the token owner or approved users
      * MUST emit PayoutClaimed
      * SHOULD revert if there is nothing to claim

--- a/contracts/IERC5725.sol
+++ b/contracts/IERC5725.sol
@@ -11,35 +11,43 @@ import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
  */
 interface IERC5725 is IERC721 {
     /**
-     *  This event is emitted when the payout is claimed through the claim function
-     *  @param tokenId the NFT tokenId of the assets being claimed.
+     *  This event is emitted when the payout is claimed through the claim function.
+     *  @param tokenId The NFT tokenId of the assets being claimed.
      *  @param recipient The address which is receiving the payout.
      *  @param claimAmount The amount of tokens being claimed.
      */
     event PayoutClaimed(uint256 indexed tokenId, address indexed recipient, uint256 claimAmount);
 
     /**
-     * @notice Claim the pending payout for the NFT
-     * @dev MUST grant the claimablePayout value at the time of claim being called
-     * MUST revert if not called by the token owner or approved users
-     * MUST emit PayoutClaimed
-     * SHOULD revert if there is nothing to claim
-     * @param tokenId The NFT token id
+     *  This event is emitted when an allowance has been increased or decreased.
+     *  @param owner The owner of an NFT who's entitled to vested tokens.
+     *  @param spender The address who is given permission to spend vested tokens.
+     *  @param value The updated amount of tokens that have been approved.
+     */
+    event ClaimApproval(address owner, address spender, uint256 value);
+
+    /**
+     * @notice Claim the pending payout for the NFT.
+     * @dev MUST grant the claimablePayout value at the time of claim being called.
+     * MUST revert if not called by the token owner or approved users.
+     * MUST emit PayoutClaimed.
+     * SHOULD revert if there is nothing to claim.
+     * @param tokenId The NFT token id.
      */
     function claim(uint256 tokenId) external;
 
     /**
-     * @notice Number of tokens for the NFT which have been claimed at the current timestamp
-     * @param tokenId The NFT token id
-     * @return payout The total amount of payout tokens claimed for this NFT
+     * @notice Number of tokens for the NFT which have been claimed at the current timestamp.
+     * @param tokenId The NFT token id.
+     * @return payout The total amount of payout tokens claimed for this NFT.
      */
     function claimedPayout(uint256 tokenId) external view returns (uint256 payout);
 
     /**
-     * @notice Number of tokens for the NFT which can be claimed at the current timestamp
+     * @notice Number of tokens for the NFT which can be claimed at the current timestamp.
      * @dev It is RECOMMENDED that this is calculated as the `vestedPayout()` subtracted from `payoutClaimed()`.
-     * @param tokenId The NFT token id
-     * @return payout The amount of unlocked payout tokens for the NFT which have not yet been claimed
+     * @param tokenId The NFT token id.
+     * @return payout The amount of unlocked payout tokens for the NFT which have not yet been claimed.
      */
     function claimablePayout(uint256 tokenId) external view returns (uint256 payout);
 
@@ -48,7 +56,7 @@ interface IERC5725 is IERC721 {
      *   This number also includes vested tokens which have been claimed.
      * @dev It is RECOMMENDED that this function calls `vestedPayoutAtTime` with
      *   `block.timestamp` as the `timestamp` parameter.
-     * @param tokenId The NFT token id
+     * @param tokenId The NFT token id.
      * @return payout Total amount of tokens which have been vested at the current timestamp.
      */
     function vestedPayout(uint256 tokenId) external view returns (uint256 payout);
@@ -58,16 +66,16 @@ interface IERC5725 is IERC721 {
      *   This number also includes vested tokens which have been claimed.
      * @dev `timestamp` MAY be both in the future and in the past.
      * Zero MUST be returned if the timestamp is before the token was minted.
-     * @param tokenId The NFT token id
-     * @param timestamp The timestamp to check on, can be both in the past and the future
-     * @return payout Total amount of tokens which have been vested at the provided timestamp
+     * @param tokenId The NFT token id.
+     * @param timestamp The timestamp to check on, can be both in the past and the future.
+     * @return payout Total amount of tokens which have been vested at the provided timestamp.
      */
     function vestedPayoutAtTime(uint256 tokenId, uint256 timestamp) external view returns (uint256 payout);
 
     /**
      * @notice Number of tokens for an NFT which are currently vesting.
      * @dev The sum of vestedPayout and vestingPayout SHOULD always be the total payout.
-     * @param tokenId The NFT token id
+     * @param tokenId The NFT token id.
      * @return payout The number of tokens for the NFT which are vesting until a future date.
      */
     function vestingPayout(uint256 tokenId) external view returns (uint256 payout);
@@ -75,16 +83,45 @@ interface IERC5725 is IERC721 {
     /**
      * @notice The start and end timestamps for the vesting of the provided NFT
      * MUST return the timestamp where no further increase in vestedPayout occurs for `vestingEnd`.
-     * @param tokenId The NFT token id
-     * @return vestingStart The beginning of the vesting as a unix timestamp
-     * @return vestingEnd The ending of the vesting as a unix timestamp
+     * @param tokenId The NFT token id.
+     * @return vestingStart The beginning of the vesting as a unix timestamp.
+     * @return vestingEnd The ending of the vesting as a unix timestamp.
      */
     function vestingPeriod(uint256 tokenId) external view returns (uint256 vestingStart, uint256 vestingEnd);
 
     /**
-     * @notice Token which is used to pay out the vesting claims
-     * @param tokenId The NFT token id
-     * @return token The token which is used to pay out the vesting claims
+     * @notice Token which is used to pay out the vesting claims.
+     * @param tokenId The NFT token id.
+     * @return token The token which is used to pay out the vesting claims.
      */
     function payoutToken(uint256 tokenId) external view returns (address token);
+
+    /**
+     * @notice Atomically increases the allowance granted to `spender` by the caller.
+     * @dev `spender` cannot be the zero address.
+     * @dev Emits an {ClaimApproval} event indicating the updated allowance value.
+     * @param spender The `spender` to be granted allowance.
+     * @param addedValue The allowance granted to `spender`.
+     */
+    function increaseClaimAllowance(address spender, uint256 addedValue) external;
+    
+    /**
+     * @notice Atomically decreases the allowance granted to `spender` by the caller.
+     * @dev `spender` cannot be the zero address.
+     * @dev Emits an {ClaimApproval} event indicating the updated allowance value.
+     * @param spender The `spender` to have allowance reduced.
+     * @param subtractedValue The allowance decreased from `spender`.
+     */
+    function decreaseClaimAllowance(address spender, uint256 subtractedValue) external;
+
+    /**
+     * @notice Total amount of allowance granted to a particular `spender`.
+     * @dev `owner` cannot be the zero address.
+     * @dev `spender` cannot be the zero address.
+     * @param owner The allowance giver.
+     * @param spender The allowance sender.
+     * @return result The number of tokens permitted to be spent by the `spender`.
+     */
+    function allowance(address owner, address spender) external view returns (uint256 result);
 }
+

--- a/contracts/IERC5725.sol
+++ b/contracts/IERC5725.sol
@@ -3,15 +3,13 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
 /**
- * @title Non-Fungible Vesting Token Standard
- * @notice A non-fungible token standard used to vest ERC-20 tokens over a vesting release curve
- *  scheduled using timestamps.
- * @dev Because this standard relies on timestamps for the vesting schedule, it's important to keep track of the
- *  tokens claimed per Vesting NFT so that a user cannot withdraw more tokens than alloted for a specific Vesting NFT.
+ * @title Non-Fungible Vesting Token Standard.
+ * @notice A non-fungible token standard used to vest ERC-20 tokens over a vesting release curve scheduled using timestamps.
+ * @dev Because this standard relies on timestamps for the vesting schedule, it's important to keep track of the tokens claimed per Vesting NFT so that a user cannot withdraw more tokens than allotted for a specific Vesting NFT.
  */
 interface IERC5725 is IERC721 {
     /**
-     *  This event is emitted when the payout is claimed through the claim function
+     *  This event is emitted when the payout is claimed through the claim function.
      *  @param tokenId the NFT tokenId of the assets being claimed.
      *  @param recipient The address which is receiving the payout.
      *  @param claimAmount The amount of tokens being claimed.
@@ -19,72 +17,81 @@ interface IERC5725 is IERC721 {
     event PayoutClaimed(uint256 indexed tokenId, address indexed recipient, uint256 claimAmount);
 
     /**
-     * @notice Claim the pending payout for the NFT
-     * @dev MUST grant the claimablePayout value at the time of claim being called to `msg.sender`
-     * MUST revert if not called by the token owner or approved users
-     * MUST emit PayoutClaimed
-     * SHOULD revert if there is nothing to claim
-     * @param tokenId The NFT token id
+     *  This event is emitted when an `owner` sets an address to manage token claims for all tokens.
+     *  @param owner The address setting a manager to manage all tokens.
+     *  @param spender The address being permitted to manage all tokens.
+     *  @param approved A boolean indicating whether the spender is approved to claim for all tokens.
+     */
+    event ClaimApprovalForAll(address indexed owner, address indexed spender, bool approved);
+
+    /**
+     *  This event is emitted when an `owner` sets an address to manage token claims for a `tokenId`.
+     *  @param owner The `owner` of `tokenId`.
+     *  @param spender The address being permitted to manage a tokenId.
+     *  @param tokenId The unique identifier of the token being managed.
+     *  @param approved A boolean indicating whether the spender is approved to claim for `tokenId`.
+     */
+    event ClaimApproval(address indexed owner, address indexed spender, uint256 indexed tokenId, bool approved);
+
+    /**
+     * @notice Claim the pending payout for the NFT.
+     * @dev MUST grant the claimablePayout value at the time of claim being called to `msg.sender`. MUST revert if not called by the token owner or approved users. MUST emit PayoutClaimed. SHOULD revert if there is nothing to claim.
+     * @param tokenId The NFT token id.
      */
     function claim(uint256 tokenId) external;
 
     /**
-     * @notice Number of tokens for the NFT which have been claimed at the current timestamp
-     * @param tokenId The NFT token id
-     * @return payout The total amount of payout tokens claimed for this NFT
+     * @notice Number of tokens for the NFT which have been claimed at the current timestamp.
+     * @param tokenId The NFT token id.
+     * @return payout The total amount of payout tokens claimed for this NFT.
      */
     function claimedPayout(uint256 tokenId) external view returns (uint256 payout);
 
     /**
-     * @notice Number of tokens for the NFT which can be claimed at the current timestamp
+     * @notice Number of tokens for the NFT which can be claimed at the current timestamp.
      * @dev It is RECOMMENDED that this is calculated as the `vestedPayout()` subtracted from `payoutClaimed()`.
-     * @param tokenId The NFT token id
-     * @return payout The amount of unlocked payout tokens for the NFT which have not yet been claimed
+     * @param tokenId The NFT token id.
+     * @return payout The amount of unlocked payout tokens for the NFT which have not yet been claimed.
      */
     function claimablePayout(uint256 tokenId) external view returns (uint256 payout);
 
     /**
-     * @notice Total amount of tokens which have been vested at the current timestamp.
-     *   This number also includes vested tokens which have been claimed.
-     * @dev It is RECOMMENDED that this function calls `vestedPayoutAtTime` with
-     *   `block.timestamp` as the `timestamp` parameter.
-     * @param tokenId The NFT token id
+     * @notice Total amount of tokens which have been vested at the current timestamp. This number also includes vested tokens which have been claimed.
+     * @dev It is RECOMMENDED that this function calls `vestedPayoutAtTime` with `block.timestamp` as the `timestamp` parameter.
+     * @param tokenId The NFT token id.
      * @return payout Total amount of tokens which have been vested at the current timestamp.
      */
     function vestedPayout(uint256 tokenId) external view returns (uint256 payout);
 
     /**
-     * @notice Total amount of vested tokens at the provided timestamp.
-     *   This number also includes vested tokens which have been claimed.
-     * @dev `timestamp` MAY be both in the future and in the past.
-     * Zero MUST be returned if the timestamp is before the token was minted.
-     * @param tokenId The NFT token id
-     * @param timestamp The timestamp to check on, can be both in the past and the future
-     * @return payout Total amount of tokens which have been vested at the provided timestamp
+     * @notice Total amount of vested tokens at the provided timestamp. This number also includes vested tokens which have been claimed.
+     * @dev `timestamp` MAY be both in the future and in the past. Zero MUST be returned if the timestamp is before the token was minted.
+     * @param tokenId The NFT token id.
+     * @param timestamp The timestamp to check on, can be both in the past and the future.
+     * @return payout Total amount of tokens which have been vested at the provided timestamp.
      */
     function vestedPayoutAtTime(uint256 tokenId, uint256 timestamp) external view returns (uint256 payout);
 
     /**
      * @notice Number of tokens for an NFT which are currently vesting.
      * @dev The sum of vestedPayout and vestingPayout SHOULD always be the total payout.
-     * @param tokenId The NFT token id
+     * @param tokenId The NFT token id.
      * @return payout The number of tokens for the NFT which are vesting until a future date.
      */
     function vestingPayout(uint256 tokenId) external view returns (uint256 payout);
 
     /**
-     * @notice The start and end timestamps for the vesting of the provided NFT
-     * MUST return the timestamp where no further increase in vestedPayout occurs for `vestingEnd`.
-     * @param tokenId The NFT token id
-     * @return vestingStart The beginning of the vesting as a unix timestamp
-     * @return vestingEnd The ending of the vesting as a unix timestamp
+     * @notice The start and end timestamps for the vesting of the provided NFT. MUST return the timestamp where no further increase in vestedPayout occurs for `vestingEnd`.
+     * @param tokenId The NFT token id.
+     * @return vestingStart The beginning of the vesting as a unix timestamp.
+     * @return vestingEnd The ending of the vesting as a unix timestamp.
      */
     function vestingPeriod(uint256 tokenId) external view returns (uint256 vestingStart, uint256 vestingEnd);
 
     /**
-     * @notice Token which is used to pay out the vesting claims
-     * @param tokenId The NFT token id
-     * @return token The token which is used to pay out the vesting claims
+     * @notice Token which is used to pay out the vesting claims.
+     * @param tokenId The NFT token id.
+     * @return token The token which is used to pay out the vesting claims.
      */
     function payoutToken(uint256 tokenId) external view returns (address token);
 }

--- a/contracts/IERC5725.sol
+++ b/contracts/IERC5725.sol
@@ -37,6 +37,24 @@ interface IERC5725 is IERC721 {
     function claim(uint256 tokenId) external;
 
     /**
+     * @notice Function that allows one account to increase the allowance of another account over their tokens.
+     * @dev MUST revert if spender if the zero address.
+     * MUST emit ClaimApproval.
+     * @param spender The `spender` to be granted an allowance balance.
+     * @param addedValue The allowance granted to `spender`.
+     */
+    function increaseClaimAllowance(address spender, uint256 addedValue) external;
+
+    /**
+     * @notice Function that allows one account to decrease the allowance of another account over their tokens.
+     * @dev MUST revert if spender if the zero address.
+     * MUST emit ClaimApproval.
+     * @param spender The `spender` to have allowance balance reduced.
+     * @param subtractedValue The allowance decreased from `spender`.
+     */
+    function decreaseClaimAllowance(address spender, uint256 subtractedValue) external;
+
+    /**
      * @notice Number of tokens for the NFT which have been claimed at the current timestamp.
      * @param tokenId The NFT token id.
      * @return payout The total amount of payout tokens claimed for this NFT.
@@ -97,31 +115,10 @@ interface IERC5725 is IERC721 {
     function payoutToken(uint256 tokenId) external view returns (address token);
 
     /**
-     * @notice Atomically increases the allowance granted to `spender` by the caller.
-     * @dev `spender` cannot be the zero address.
-     * @dev Emits an {ClaimApproval} event indicating the updated allowance value.
-     * @param spender The `spender` to be granted allowance.
-     * @param addedValue The allowance granted to `spender`.
-     */
-    function increaseClaimAllowance(address spender, uint256 addedValue) external;
-    
-    /**
-     * @notice Atomically decreases the allowance granted to `spender` by the caller.
-     * @dev `spender` cannot be the zero address.
-     * @dev Emits an {ClaimApproval} event indicating the updated allowance value.
-     * @param spender The `spender` to have allowance reduced.
-     * @param subtractedValue The allowance decreased from `spender`.
-     */
-    function decreaseClaimAllowance(address spender, uint256 subtractedValue) external;
-
-    /**
-     * @notice Total amount of allowance granted to a particular `spender`.
-     * @dev `owner` cannot be the zero address.
-     * @dev `spender` cannot be the zero address.
-     * @param owner The allowance giver.
-     * @param spender The allowance sender.
-     * @return result The number of tokens permitted to be spent by the `spender`.
+     * @notice Returns the allowance that one account has given another over their token.
+     * @param owner Address that tokens are approved from.
+     * @param spender Address that tokens are approved for.
+     * @return result Allowance that one account has given another over their tokens.
      */
     function allowance(address owner, address spender) external view returns (uint256 result);
 }
-

--- a/docs/ERC5725.md
+++ b/docs/ERC5725.md
@@ -93,7 +93,7 @@ function supportsInterface(bytes4 interfaceId) public view virtual returns (bool
 ```
 
 _See {IERC165-supportsInterface}.
-IERC5725 interfaceId = 0x7c89676d_
+IERC5725 interfaceId = 0xf316c058_
 
 ### _payoutToken
 

--- a/docs/ERC5725.md
+++ b/docs/ERC5725.md
@@ -93,7 +93,7 @@ function supportsInterface(bytes4 interfaceId) public view virtual returns (bool
 ```
 
 _See {IERC165-supportsInterface}.
-IERC5725 interfaceId = 0xf316c058_
+IERC5725 interfaceId = 0xd707c82a_
 
 ### _payoutToken
 

--- a/docs/ERC5725.md
+++ b/docs/ERC5725.md
@@ -93,7 +93,7 @@ function supportsInterface(bytes4 interfaceId) public view virtual returns (bool
 ```
 
 _See {IERC165-supportsInterface}.
-IERC5725 interfaceId = 0xd707c82a_
+IERC5725 interfaceId = 0x7c89676d_
 
 ### _payoutToken
 

--- a/hardhat/types.ts
+++ b/hardhat/types.ts
@@ -17,7 +17,7 @@ export const NETWORKS = <const>[
   'hardhat',
 ]
 // Create a type out of the network array
-export type Network = typeof NETWORKS[number]
+export type Network = (typeof NETWORKS)[number]
 
 export type TaskRunOptions = {
   force?: boolean

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ape.swap/erc-5725",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Solidity Smart Contract development template using modern Web3 frameworks/tools including Hardhat, Typechain and more.",
   "main": "dist/src/index.js",
   "files": [

--- a/src/erc5725.ts
+++ b/src/erc5725.ts
@@ -3,7 +3,7 @@ import ERC5725_Artifact from '../artifacts/contracts/ERC5725.sol/ERC5725.json'
 import { ERC5725 } from '../typechain-types'
 
 // This constant represents the interface ID of the IERC5725 contract.
-export const IERC5725_InterfaceId = '0xd707c82a'
+export const IERC5725_InterfaceId = '0x7c89676d'
 
 /**
  * This function returns an instance of the ERC5725 contract, which is a smart contract that implements the IERC5725 interface.

--- a/src/erc5725.ts
+++ b/src/erc5725.ts
@@ -3,7 +3,7 @@ import ERC5725_Artifact from '../artifacts/contracts/ERC5725.sol/ERC5725.json'
 import { ERC5725 } from '../typechain-types'
 
 // This constant represents the interface ID of the IERC5725 contract.
-export const IERC5725_InterfaceId = '0x7c89676d'
+export const IERC5725_InterfaceId = '0xf316c058'
 
 /**
  * This function returns an instance of the ERC5725 contract, which is a smart contract that implements the IERC5725 interface.

--- a/src/erc5725.ts
+++ b/src/erc5725.ts
@@ -3,7 +3,7 @@ import ERC5725_Artifact from '../artifacts/contracts/ERC5725.sol/ERC5725.json'
 import { ERC5725 } from '../typechain-types'
 
 // This constant represents the interface ID of the IERC5725 contract.
-export const IERC5725_InterfaceId = '0xf316c058'
+export const IERC5725_InterfaceId = '0xd707c82a'
 
 /**
  * This function returns an instance of the ERC5725 contract, which is a smart contract that implements the IERC5725 interface.

--- a/test/VestingNFT.test.ts
+++ b/test/VestingNFT.test.ts
@@ -169,8 +169,6 @@ describe('VestingNFT', function () {
     ).to.revertedWith('to cannot be address 0')
   })
 
-  //MINE
-
   it('Owner can set a spender with an allowance that can be spent', async function () {
     // Setup allowance exactly equal to claimable amount
     const allowanceAmount = testValues.payout
@@ -284,7 +282,7 @@ describe('VestingNFT', function () {
     expect(postClaim2Allowance.toString()).to.equal((0).toString())
   })
 
-  it('Allowances set by an account aren\'t reset when NFT is transferred', async function () {
+  it("Allowances set by an account aren't reset when NFT is transferred", async function () {
     // Set an allowance for spender
     const allowanceAmount = testValues.payout
     const connectedVestingNft = vestingNFT.connect(accounts[1])
@@ -319,8 +317,6 @@ describe('VestingNFT', function () {
       allowanceAmount.toString()
     )
   })
-
-  // MINE END
 })
 
 async function createVestingNft(

--- a/test/VestingNFT.test.ts
+++ b/test/VestingNFT.test.ts
@@ -1,5 +1,5 @@
 import { ethers } from 'hardhat'
-import { Signer } from 'ethers'
+import { BigNumber, Signer } from 'ethers'
 import { expect } from 'chai'
 import { time } from '@nomicfoundation/hardhat-network-helpers'
 // typechain
@@ -8,6 +8,7 @@ import { IERC5725_InterfaceId } from '../src/erc5725'
 
 const testValues = {
   payout: '1000000000',
+  payoutDecimals: 18,
   lockTime: 60,
 }
 
@@ -16,7 +17,9 @@ describe('VestingNFT', function () {
   let vestingNFT: VestingNFT
   let mockToken: ERC20Mock
   let receiverAccount: string
+  let spenderAccount: string
   let unlockTime: number
+  let invalidTokenID = 1337
 
   beforeEach(async function () {
     const VestingNFT = await ethers.getContractFactory('VestingNFT')
@@ -26,7 +29,7 @@ describe('VestingNFT', function () {
     const ERC20Mock = await ethers.getContractFactory('ERC20Mock')
     mockToken = await ERC20Mock.deploy(
       '1000000000000000000000',
-      18,
+      testValues.payoutDecimals,
       'LockedToken',
       'LOCK'
     )
@@ -35,7 +38,13 @@ describe('VestingNFT', function () {
 
     accounts = await ethers.getSigners()
     receiverAccount = await accounts[1].getAddress()
-    unlockTime = await createVestingNft(vestingNFT, receiverAccount, mockToken)
+    spenderAccount = await accounts[2].getAddress()
+    unlockTime = await createVestingNft(
+      vestingNFT,
+      receiverAccount,
+      mockToken,
+      5
+    )
   })
 
   it('Supports ERC721 and IERC5725 interfaces', async function () {
@@ -63,25 +72,25 @@ describe('VestingNFT', function () {
   })
 
   it('Reverts with invalid ID', async function () {
-    await expect(vestingNFT.vestedPayout(1)).to.revertedWith(
+    await expect(vestingNFT.vestedPayout(invalidTokenID)).to.revertedWith(
       'ERC5725: invalid token ID'
     )
-    await expect(vestingNFT.vestedPayoutAtTime(1, unlockTime)).to.revertedWith(
+    await expect(
+      vestingNFT.vestedPayoutAtTime(invalidTokenID, unlockTime)
+    ).to.revertedWith('ERC5725: invalid token ID')
+    await expect(vestingNFT.vestingPayout(invalidTokenID)).to.revertedWith(
       'ERC5725: invalid token ID'
     )
-    await expect(vestingNFT.vestingPayout(1)).to.revertedWith(
+    await expect(vestingNFT.claimablePayout(invalidTokenID)).to.revertedWith(
       'ERC5725: invalid token ID'
     )
-    await expect(vestingNFT.claimablePayout(1)).to.revertedWith(
+    await expect(vestingNFT.vestingPeriod(invalidTokenID)).to.revertedWith(
       'ERC5725: invalid token ID'
     )
-    await expect(vestingNFT.vestingPeriod(1)).to.revertedWith(
+    await expect(vestingNFT.payoutToken(invalidTokenID)).to.revertedWith(
       'ERC5725: invalid token ID'
     )
-    await expect(vestingNFT.payoutToken(1)).to.revertedWith(
-      'ERC5725: invalid token ID'
-    )
-    await expect(vestingNFT.claim(1)).to.revertedWith(
+    await expect(vestingNFT.claim(invalidTokenID)).to.revertedWith(
       'ERC5725: invalid token ID'
     )
     // NOTE: Removed claimTo from spec
@@ -127,10 +136,10 @@ describe('VestingNFT', function () {
     )
   })
 
-  it('Reverts claim when payout is not from owner', async function () {
+  it('Reverts claim when payout is not from owner or account with permission', async function () {
     const connectedVestingNft = vestingNFT.connect(accounts[2])
     await expect(connectedVestingNft.claim(0)).to.revertedWith(
-      'Not owner of NFT'
+      'ERC5725: not owner of NFT or no permission to spend'
     )
   })
 
@@ -159,21 +168,179 @@ describe('VestingNFT', function () {
       )
     ).to.revertedWith('to cannot be address 0')
   })
+
+  //MINE
+
+  it('Owner can set a spender with an allowance that can be spent', async function () {
+    // Setup allowance exactly equal to claimable amount
+    const allowanceAmount = testValues.payout
+    const connectedVestingNft = vestingNFT.connect(accounts[1])
+    let increaseAllowanceTx = await connectedVestingNft.increaseClaimAllowance(
+      spenderAccount,
+      allowanceAmount
+    )
+    await increaseAllowanceTx.wait()
+    // Do we have the expected allowance in state?
+    const getCurrentAllowance = await vestingNFT.allowance(
+      receiverAccount,
+      spenderAccount
+    )
+    expect(getCurrentAllowance.toString()).to.equal(allowanceAmount.toString())
+    await time.increase(testValues.lockTime)
+    // Connect with the spenderAccount and claim our allowance
+    const connectedAllowanceVestingNft = vestingNFT.connect(accounts[2])
+    let claimTx = await connectedAllowanceVestingNft.claim(0)
+    await claimTx.wait()
+    // Do we have allowance 0 since we claimed all of our allowance?
+    const postClaimAllowance = await vestingNFT.allowance(
+      receiverAccount,
+      spenderAccount
+    )
+    expect(postClaimAllowance.toString()).to.equal((0).toString())
+    // Compare balance after claim, spender now has tokens, owner doesn't
+    const spenderPostClaimBalance = await mockToken.balanceOf(spenderAccount)
+    expect(spenderPostClaimBalance.toString()).to.equal(
+      testValues.payout.toString()
+    )
+    const ownerPostClaimBalance = await mockToken.balanceOf(receiverAccount)
+    expect(ownerPostClaimBalance.toString()).to.equal(BigNumber.from(0))
+  })
+
+  it('Spender cannot overspend allowance', async function () {
+    // Setup allowance to be less than claimable amount
+    const allowanceAmount = Number(testValues.payout) / 2
+    const connectedVestingNft = vestingNFT.connect(accounts[1])
+    let increaseAllowanceTx = await connectedVestingNft.increaseClaimAllowance(
+      spenderAccount,
+      allowanceAmount
+    )
+    await increaseAllowanceTx.wait()
+    // Do we have the expected allowance in state?
+    const getCurrentAllowance = await vestingNFT.allowance(
+      receiverAccount,
+      spenderAccount
+    )
+    expect(getCurrentAllowance.toString()).to.equal(allowanceAmount.toString())
+    await time.increase(testValues.lockTime)
+    // Connect with the spenderAccount and since our allowance is less than the vestedPayout, we are unable to claim. Allowance:n-1 Claimable:n
+    const connectedAllowanceVestingNft = vestingNFT.connect(accounts[2])
+    await expect(connectedAllowanceVestingNft.claim(0)).to.be.revertedWith(
+      'ERC5725: insufficient allowance'
+    )
+    // We should still have our original allowance
+    const postClaimAllowance = await vestingNFT.allowance(
+      receiverAccount,
+      spenderAccount
+    )
+    expect(postClaimAllowance.toString()).to.equal(allowanceAmount.toString())
+  })
+
+  it('Owner can set a spender with an allowance that can be claimed across multiple tokenIds ', async function () {
+    // Set the allowance to twice the payout value
+    const allowanceAmount = Number(testValues.payout) * 2
+    const connectedVestingNft = vestingNFT.connect(accounts[1])
+    let increaseAllowanceTx = await connectedVestingNft.increaseClaimAllowance(
+      spenderAccount,
+      allowanceAmount
+    )
+    await increaseAllowanceTx.wait()
+    // Do we have the expected allowance in state?
+    const getCurrentAllowance = await vestingNFT.allowance(
+      receiverAccount,
+      spenderAccount
+    )
+    expect(getCurrentAllowance.toString()).to.equal(allowanceAmount.toString())
+    await time.increase(testValues.lockTime)
+    // Connect with the spenderAccount and claim our allowance
+    const connectedAllowanceVestingNft = vestingNFT.connect(accounts[2])
+    let claimTx1 = await connectedAllowanceVestingNft.claim(0)
+    await claimTx1.wait()
+    // Compare balance after claim, spender now has tokens
+    const spenderPostClaim1Balance = await mockToken.balanceOf(spenderAccount)
+    expect(spenderPostClaim1Balance.toString()).to.equal(
+      testValues.payout.toString()
+    )
+    // The allowance should be reduced by the payout
+    let postClaim1Allowance = await vestingNFT.allowance(
+      receiverAccount,
+      spenderAccount
+    )
+    expect(postClaim1Allowance.toString()).to.equal(
+      testValues.payout.toString()
+    )
+    // Now claim from the second token
+    let claimTx2 = await connectedAllowanceVestingNft.claim(1)
+    await claimTx2.wait()
+    // Check the spender balance, should now be twice the payout
+    const spenderPostClaim2Balance = await mockToken.balanceOf(spenderAccount)
+    expect(spenderPostClaim2Balance.toString()).to.equal(
+      (Number(testValues.payout) * 2).toString()
+    )
+    // The allowance should now be 0 since we claimed all of our allowance
+    let postClaim2Allowance = await vestingNFT.allowance(
+      receiverAccount,
+      spenderAccount
+    )
+    expect(postClaim2Allowance.toString()).to.equal((0).toString())
+  })
+
+  it('Allowances set by an account aren\'t reset when NFT is transferred', async function () {
+    // Set an allowance for spender
+    const allowanceAmount = testValues.payout
+    const connectedVestingNft = vestingNFT.connect(accounts[1])
+    let increaseAllowanceTx = await connectedVestingNft.increaseClaimAllowance(
+      spenderAccount,
+      allowanceAmount
+    )
+    await increaseAllowanceTx.wait()
+
+    // Check the allowance is set correctly
+    const getCurrentAllowance = await vestingNFT.allowance(
+      receiverAccount,
+      spenderAccount
+    )
+    expect(getCurrentAllowance.toString()).to.equal(allowanceAmount.toString())
+
+    // Transfer NFT from receiver to a different account
+    const connectedReceiverVestingNft = vestingNFT.connect(accounts[1])
+    let transferTx = await connectedReceiverVestingNft.transferFrom(
+      receiverAccount,
+      spenderAccount,
+      0
+    )
+    await transferTx.wait()
+
+    // Check that the allowance is still the same even though the NFT was transferred
+    const postTransferAllowance = await vestingNFT.allowance(
+      receiverAccount,
+      spenderAccount
+    )
+    expect(postTransferAllowance.toString()).to.equal(
+      allowanceAmount.toString()
+    )
+  })
+
+  // MINE END
 })
 
 async function createVestingNft(
   vestingNFT: VestingNFT,
   receiverAccount: string,
-  mockToken: ERC20Mock
+  mockToken: ERC20Mock,
+  batchMintAmount: number = 1
 ) {
   const latestBlock = await ethers.provider.getBlock('latest')
   const unlockTime = latestBlock.timestamp + testValues.lockTime
-  const txReceipt = await vestingNFT.create(
-    receiverAccount,
-    testValues.payout,
-    unlockTime,
-    mockToken.address
-  )
-  await txReceipt.wait()
+
+  for (let i = 0; i <= batchMintAmount; i++) {
+    const txReceipt = await vestingNFT.create(
+      receiverAccount,
+      testValues.payout,
+      unlockTime,
+      mockToken.address
+    )
+    await txReceipt.wait()
+  }
+
   return unlockTime
 }


### PR DESCRIPTION
# Claim Allowances

ERC-5725 provides an allowance mechanism for the owner of a token to set a `spender` with an `amount` which may call `claim(tokenId)` on behalf of the owner. The `amount` can be claimed across multiple `tokenIds`. The allowance `amount` is not reset if the owner transfers all of their NFT's away, the allowance maybe spent in the future if owner reaquires a token.

![image](https://github.com/ApeSwapFinance/eip-5725-vesting-nft-implementation/assets/10979087/09354331-dbe3-43a9-99e0-35afb54d9082)

---

I've based this on the discussions I've had with ApeGuru. The allowance pattern is similar to IERC20, whereby the allowance is not reset, it uses the logic from the newer Increase/DecreaseAllowance logic, over the [older approve style](https://docs.openzeppelin.com/contracts/2.x/api/token/erc20#IERC20-approve-address-uint256-) - this is in constrast to IERC721 which will remove the allowances once your NFT balance is 0 due to it using the tokenId as the key, rather than address in IERC20. Because we are using address allowances like IERC20, I chose not to reset the balance when the users NFT count is zero. This has the quirk when the user aquires a new token in the future, the allowance is still valid.

This allowance logic is required for 5725 to have any meaningful infrastructure build around it. Currently the specification will only allow the owner to call `claim(tokenId)` which has the following effects which are all attributed to not having any approvals for a third party to claim.

1. Supporting infrastructure could not claim on behalf of the user
2. Contracts cannot batch multiple `claim(tokenId)`'s together since the proxy contract is not the owner.

Viva la 5725. 

